### PR TITLE
chore: hash playground assets for cache invalidation

### DIFF
--- a/examples/todotxt-playground/config/webpack.config.ts
+++ b/examples/todotxt-playground/config/webpack.config.ts
@@ -34,6 +34,7 @@ export default function createConfig(mode = Environment.Development): Configurat
       minimizer: [new TerserWebpackPlugin()],
     },
     output: {
+      filename: "[name].[hash].js",
       path: path.resolve(packageRoot, "build"),
     },
     plugins: [


### PR DESCRIPTION
Adds a hash to the assets generated by the playground's webpack build to invalidate the cache.